### PR TITLE
usd price updates, volume updates, move liquidity and rate logic to sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 src/types/
 .DS_STORE
 yarn-error.log
+.vscode/settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ node_modules/
 src/types/
 .DS_STORE
 yarn-error.log
-.vscode/settings.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "python.formatting.provider": "black"
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "graph build",
     "create-local": "graph create davekaj/uniswap --node http://127.0.0.1:8020",
     "deploy-local": "graph deploy davekaj/uniswap --debug --ipfs http://localhost:5001 --node http://127.0.0.1:8020",
-    "deploy": "graph deploy ianlapham/uniswap2 --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/ --debug",
+    "deploy": "graph deploy ianlapham/uniswap-v2-local --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/ --debug",
     "deploy-staging": "graph deploy $THE_GRAPH_GITHUB_USER/$THE_GRAPH_SUBGRAPH_NAME /Uniswap --ipfs https://api.staging.thegraph.com/ipfs/ --node https://api.staging.thegraph.com/deploy/",
     "watch-local": "graph deploy graphprotocol/Uniswap2 --watch --debug --node http://127.0.0.1:8020/ --ipfs http://localhost:5001"
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "graph build",
     "create-local": "graph create davekaj/uniswap --node http://127.0.0.1:8020",
     "deploy-local": "graph deploy davekaj/uniswap --debug --ipfs http://localhost:5001 --node http://127.0.0.1:8020",
-    "deploy": "graph deploy ianlapham/uniswap-v2-local --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/ --debug",
+    "deploy": "graph deploy ianlapham/uniswap2 --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/ --debug",
     "deploy-staging": "graph deploy $THE_GRAPH_GITHUB_USER/$THE_GRAPH_SUBGRAPH_NAME /Uniswap --ipfs https://api.staging.thegraph.com/ipfs/ --node https://api.staging.thegraph.com/deploy/",
     "watch-local": "graph deploy graphprotocol/Uniswap2 --watch --debug --node http://127.0.0.1:8020/ --ipfs http://localhost:5001"
   },

--- a/schema.graphql
+++ b/schema.graphql
@@ -44,7 +44,6 @@ type Token @entity {
   derivedETH: BigDecimal
 
   # address of weth exchange if exists
-  wethPair: Pair
   allPairs: [Pair!]
 
   # saved for historical refernce of most liquid pairs

--- a/schema.graphql
+++ b/schema.graphql
@@ -28,7 +28,7 @@ type Token @entity {
   # mirrored from the smart contract
   symbol: String!
   name: String!
-  decimals: Int!
+  decimals: BigInt!
 
   # token specific volume
   tradeVolume: BigDecimal!
@@ -63,8 +63,9 @@ type Pair @entity {
   totalSupply: BigDecimal!
 
   # derived liquidity 
-  reserveETH: BigDecimal 
+  reserveETH: BigDecimal!
   reserveUSD: BigDecimal!
+  trackedReserveETH: BigDecimal! # used for separating per pair reserves and global
 
   # Price in terms of the asset pair
   token0Price: BigDecimal!

--- a/src/mappings/factory.ts
+++ b/src/mappings/factory.ts
@@ -6,8 +6,6 @@ import { Pair as PairTemplate } from '../types/templates'
 import { FACTORY_ADDRESS, ZERO_BD, ZERO_BI, fetchTokenSymbol, fetchTokenName, fetchTokenDecimals } from './helpers'
 
 export function handleNewPair(event: PairCreated): void {
-  log.debug('New Exchange: {}', [event.params.pair.toHex()])
-
   // load factory (create if first exchange)
   let factory = UniswapFactory.load(FACTORY_ADDRESS)
   if (factory == null) {
@@ -41,6 +39,7 @@ export function handleNewPair(event: PairCreated): void {
     let decimals = fetchTokenDecimals(event.params.token0)
     // bail if we couldn't figure out the decimals
     if (decimals === null) {
+      log.debug('mybug the decimal on token 0 was null', [])
       return
     }
 
@@ -60,8 +59,10 @@ export function handleNewPair(event: PairCreated): void {
     token1.symbol = fetchTokenSymbol(event.params.token1)
     token1.name = fetchTokenName(event.params.token1)
     let decimals = fetchTokenDecimals(event.params.token1)
+
     // bail if we couldn't figure out the decimals
     if (decimals === null) {
+      log.debug('mybug the decimal on token 1 was null', [])
       return
     }
     token1.decimals = decimals
@@ -90,6 +91,8 @@ export function handleNewPair(event: PairCreated): void {
   pair.txCount = ZERO_BI
   pair.reserve0 = ZERO_BD
   pair.reserve1 = ZERO_BD
+  pair.trackedReserveETH = ZERO_BD
+  pair.reserveETH = ZERO_BD
   pair.reserveUSD = ZERO_BD
   pair.totalSupply = ZERO_BD
   pair.volumeToken0 = ZERO_BD
@@ -112,3 +115,4 @@ export function handleNewPair(event: PairCreated): void {
   pair.save()
   factory.save()
 }
+// }

--- a/src/mappings/factory.ts
+++ b/src/mappings/factory.ts
@@ -1,5 +1,5 @@
 /* eslint-disable prefer-const */
-import { log, Address } from '@graphprotocol/graph-ts'
+import { log } from '@graphprotocol/graph-ts'
 import { UniswapFactory, Pair, Token, Bundle } from '../types/schema'
 import { PairCreated } from '../types/Factory/Factory'
 import { Pair as PairTemplate } from '../types/templates'
@@ -43,6 +43,7 @@ export function handleNewPair(event: PairCreated): void {
     if (decimals === null) {
       return
     }
+
     token0.decimals = decimals
     token0.derivedETH = ZERO_BD
     token0.tradeVolume = ZERO_BD
@@ -96,15 +97,6 @@ export function handleNewPair(event: PairCreated): void {
   pair.volumeUSD = ZERO_BD
   pair.token0Price = ZERO_BD
   pair.token1Price = ZERO_BD
-
-  // set weth exchange if exists
-  // TODO change to mainnet WETH
-  let WETHAddress = Address.fromString('0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2')
-  if (event.params.token0 == WETHAddress) {
-    token1.wethPair = pair.id
-  } else if (event.params.token1 == WETHAddress) {
-    token0.wethPair = pair.id
-  }
 
   // update factory totals
   let factoryPairs = factory.pairs

--- a/src/mappings/helpers.ts
+++ b/src/mappings/helpers.ts
@@ -13,12 +13,13 @@ export let ZERO_BI = BigInt.fromI32(0)
 export let ONE_BI = BigInt.fromI32(1)
 export let ZERO_BD = BigDecimal.fromString('0')
 export let ONE_BD = BigDecimal.fromString('1')
+export let BI_18 = BigInt.fromI32(18)
 
 export let factoryContract = FairContract.bind(Address.fromString(FACTORY_ADDRESS))
 
-export function exponentToBigDecimal(decimals: i32): BigDecimal {
+export function exponentToBigDecimal(decimals: BigInt): BigDecimal {
   let bd = BigDecimal.fromString('1')
-  for (let i = 0; i < decimals; i++) {
+  for (let i = ZERO_BI; i.lt(decimals as BigInt); i = i.plus(ONE_BI)) {
     bd = bd.times(BigDecimal.fromString('10'))
   }
   return bd
@@ -32,8 +33,8 @@ export function convertEthToDecimal(eth: BigInt): BigDecimal {
   return eth.toBigDecimal().div(exponentToBigDecimal(18))
 }
 
-export function convertTokenToDecimal(tokenAmount: BigInt, exchangeDecimals: i32): BigDecimal {
-  if (exchangeDecimals == 0) {
+export function convertTokenToDecimal(tokenAmount: BigInt, exchangeDecimals: BigInt): BigDecimal {
+  if (exchangeDecimals == ZERO_BI) {
     return tokenAmount.toBigDecimal()
   }
   return tokenAmount.toBigDecimal().div(exponentToBigDecimal(exchangeDecimals))
@@ -53,6 +54,11 @@ export function isNullEthValue(value: string): boolean {
 }
 
 export function fetchTokenSymbol(tokenAddress: Address): string {
+  // hard coded override
+  if (tokenAddress.toHexString() == '0xe0b7927c4af23765cb51314a0e0521a9645f0e2a') {
+    return 'DGD'
+  }
+
   let contract = ERC20.bind(tokenAddress)
   let contractSymbolBytes = ERC20SymbolBytes.bind(tokenAddress)
 
@@ -75,6 +81,11 @@ export function fetchTokenSymbol(tokenAddress: Address): string {
 }
 
 export function fetchTokenName(tokenAddress: Address): string {
+  // hard coded override
+  if (tokenAddress.toHexString() == '0xe0b7927c4af23765cb51314a0e0521a9645f0e2a') {
+    return 'DGD'
+  }
+
   let contract = ERC20.bind(tokenAddress)
   let contractNameBytes = ERC20NameBytes.bind(tokenAddress)
 
@@ -96,16 +107,15 @@ export function fetchTokenName(tokenAddress: Address): string {
   return nameValue
 }
 
-export function fetchTokenDecimals(tokenAddress: Address): i32 {
+export function fetchTokenDecimals(tokenAddress: Address): BigInt {
   let contract = ERC20.bind(tokenAddress)
-
   // try types uint8 for decimals
   let decimalValue = null
   let decimalResult = contract.try_decimals()
   if (!decimalResult.reverted) {
     decimalValue = decimalResult.value
   }
-  return decimalValue
+  return BigInt.fromI32(decimalValue as i32)
 }
 
 export function createLiquidityPosition(exchange: Address, user: Address): LiquidityPosition {

--- a/src/mappings/helpers.ts
+++ b/src/mappings/helpers.ts
@@ -4,6 +4,7 @@ import { ERC20 } from '../types/Factory/ERC20'
 import { ERC20SymbolBytes } from '../types/Factory/ERC20SymbolBytes'
 import { ERC20NameBytes } from '../types/Factory/ERC20NameBytes'
 import { User, LiquidityPosition } from '../types/schema'
+import { Factory as FairContract } from '../types/templates/Pair/Factory'
 
 export const ADDRESS_ZERO = '0x0000000000000000000000000000000000000000'
 export const FACTORY_ADDRESS = '0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f'
@@ -11,6 +12,9 @@ export const FACTORY_ADDRESS = '0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f'
 export let ZERO_BI = BigInt.fromI32(0)
 export let ONE_BI = BigInt.fromI32(1)
 export let ZERO_BD = BigDecimal.fromString('0')
+export let ONE_BD = BigDecimal.fromString('1')
+
+export let factoryContract = FairContract.bind(Address.fromString(FACTORY_ADDRESS))
 
 export function exponentToBigDecimal(decimals: i32): BigDecimal {
   let bd = BigDecimal.fromString('1')

--- a/src/mappings/pricing.ts
+++ b/src/mappings/pricing.ts
@@ -1,7 +1,7 @@
 /* eslint-disable prefer-const */
 import { Pair, Token, Bundle } from '../types/schema'
 import { BigDecimal, Address } from '@graphprotocol/graph-ts/index'
-import { ZERO_BD, ONE_BD, factoryContract, ADDRESS_ZERO } from './helpers'
+import { ZERO_BD, factoryContract, ADDRESS_ZERO } from './helpers'
 
 const DAI_WETH_PAIR = '0xa478c2975ab1ea89e8196811f51a7b7ade33eb11'
 const DAI_ADDRESS = '0x6b175474e89094c44da98b954eedeac495271d0f'
@@ -9,15 +9,15 @@ const DAI_ADDRESS = '0x6b175474e89094c44da98b954eedeac495271d0f'
 const USDC_WETH_PAIR = '0xb4e16d0168e52d35cacd2c6185b44281ec28c9dc'
 const USDC_ADDRESS = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
 
-const USDT_ADDRESS = '0xdac17f958d2ee523a2206206994597c13d831ec7'
 const USDT_WETH_PAIR = '0x0d4a11d5eeaac28ec3f61d100daf4d40471f1852'
+const USDT_ADDRESS = '0xdac17f958d2ee523a2206206994597c13d831ec7'
 
 const WETH_ADDRESS = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
 
 // only count derived ETH prices in WETH pairs with at least this much WETH reserve
 let ETH_RESERVE_THRESHOLD = BigDecimal.fromString('0.1')
 
-function deriveEthPrice(pairAddress: string, tokenAddress: string): BigDecimal {
+function getTokensPerEth(pairAddress: string, tokenAddress: string): BigDecimal {
   let tokensPerEth = ZERO_BD
   // loop through each stablecoin and find eth price
   let pair = Pair.load(Address.fromString(pairAddress).toHexString())
@@ -33,9 +33,9 @@ function deriveEthPrice(pairAddress: string, tokenAddress: string): BigDecimal {
 
 export function getEthPriceInUSD(): BigDecimal {
   // fetch eth prices for each stablecoin
-  let daiPerEth = deriveEthPrice(DAI_WETH_PAIR, DAI_ADDRESS)
-  let usdcPerEth = deriveEthPrice(USDC_WETH_PAIR, USDC_ADDRESS)
-  let usdtPerEth = deriveEthPrice(USDT_WETH_PAIR, USDT_ADDRESS)
+  let daiPerEth = getTokensPerEth(DAI_WETH_PAIR, DAI_ADDRESS)
+  let usdcPerEth = getTokensPerEth(USDC_WETH_PAIR, USDC_ADDRESS)
+  let usdtPerEth = getTokensPerEth(USDT_WETH_PAIR, USDT_ADDRESS)
 
   // return weighted average of prices
   return daiPerEth
@@ -92,42 +92,25 @@ export function findEthPerToken(token: Token, maxDepthReached: boolean): BigDeci
   return ZERO_BD /** @todo may want to return null */
 }
 
-// only return price of WETH and stabelcoins in USD, everything else is 0
-function getStrictPriceOfToken(tokenAddress: string): BigDecimal {
-  let bundle = Bundle.load('1')
-  if (tokenAddress == WETH_ADDRESS) {
-    return bundle.ethPrice
-  }
-  if (tokenAddress == DAI_ADDRESS) {
-    let dai = Token.load(DAI_ADDRESS)
-    if (dai != null) {
-      return dai.derivedETH.times(bundle.ethPrice)
-    } else {
-      return ONE_BD // in the case where DAI pair hasnt been created yet
-    }
-  }
-  if (tokenAddress == USDC_ADDRESS) {
-    let usdc = Token.load(USDC_ADDRESS)
-    if (usdc != null) {
-      return usdc.derivedETH.times(bundle.ethPrice)
-    } else {
-      return ONE_BD // in the case where DAI pair hasnt been created yet
-    }
-  }
-  return ZERO_BD
-}
+// token where amounts should contribute to tracked volume and liquidity
+let WHITELIST: string[] = [
+  '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2', // WETH
+  '0x6b175474e89094c44da98b954eedeac495271d0f', // DAI
+  '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', // USDC
+  '0xdac17f958d2ee523a2206206994597c13d831ec7', // USDT
+  '0x0000000000085d4780b73119b644ae5ecd22b376', // TUSD
+  '0x5d3a536e4d6dbd6114cc1ead35777bab948e3643', // cDAI
+  '0x39aa39c021dfbae8fac545936693ac917d5e7563', // cUSDC
+  '0x86fadb80d8d2cff3c3680819e4da99c10232ba0f', // EBASE
+  '0x57ab1ec28d129707052df4df418d58a2d46d5f51', // sUSD
+  '0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2' // MKR
+]
 
 /**
- * @param tokenAmount0
- * @param token0
- * @param tokenAmount1
- * @param token1
- *
- * Gets the strict volume amount conversion to USD.
- * Checks if either token is stablecoin or WETH,
- * if true, return the amount in that token converted to USD.
- *
- * If neither is stabelcoin or WETH, return 0
+ * Accepts tokens and amounts, return tracked amount based on token whitelist
+ * If one token on whitelist, return amount in that token converted to USD.
+ * If both are, return average of two amounts
+ * If neither is, return 0
  */
 export function getTrackedVolumeUSD(
   tokenAmount0: BigDecimal,
@@ -135,25 +118,63 @@ export function getTrackedVolumeUSD(
   tokenAmount1: BigDecimal,
   token1: Token
 ): BigDecimal {
-  let price0 = getStrictPriceOfToken(token0.id)
-  let price1 = getStrictPriceOfToken(token1.id)
+  let bundle = Bundle.load('1')
+  let price0 = token0.derivedETH.times(bundle.ethPrice)
+  let price1 = token1.derivedETH.times(bundle.ethPrice)
 
-  // if both not 0, we have a stabelcoin <-> stablecoin pair, or WETH <-> stabelcoin
-  // return average of the 2 USD amounts
-  if (price0.notEqual(ZERO_BD) && price1.notEqual(ZERO_BD)) {
+  // both are whitelist tokens, take average of both amounts
+  if (WHITELIST.includes(token0.id) && WHITELIST.includes(token1.id)) {
     return tokenAmount0
       .times(price0)
       .plus(tokenAmount1.times(price1))
       .div(BigDecimal.fromString('2'))
   }
 
-  if (price0.notEqual(ZERO_BD) && price1.equals(ZERO_BD)) {
+  // take full value of the whitelisted token amount
+  if (WHITELIST.includes(token0.id) && !WHITELIST.includes(token1.id)) {
     return tokenAmount0.times(price0)
   }
 
-  if (price1.notEqual(ZERO_BD) && price0.equals(ZERO_BD)) {
+  // take full value of the whitelisted token amount
+  if (!WHITELIST.includes(token0.id) && WHITELIST.includes(token1.id)) {
     return tokenAmount1.times(price1)
   }
 
-  return ZERO_BD // case where neither token is ETH or stablecoin
+  // neither token is on white list, tracked volume is 0
+  return ZERO_BD
+}
+
+/**
+ * Accepts tokens and amounts, return tracked amount based on token whitelist
+ * If one token on whitelist, return amount in that token converted to USD * 2.
+ * If both are, return sum of two amounts
+ * If neither is, return 0
+ */
+export function getTrackedLiquidityUSD(
+  tokenAmount0: BigDecimal,
+  token0: Token,
+  tokenAmount1: BigDecimal,
+  token1: Token
+): BigDecimal {
+  let bundle = Bundle.load('1')
+  let price0 = token0.derivedETH.times(bundle.ethPrice)
+  let price1 = token1.derivedETH.times(bundle.ethPrice)
+
+  // both are whitelist tokens, take average of both amounts
+  if (WHITELIST.includes(token0.id) && WHITELIST.includes(token1.id)) {
+    return tokenAmount0.times(price0).plus(tokenAmount1.times(price1))
+  }
+
+  // take double value of the whitelisted token amount
+  if (WHITELIST.includes(token0.id) && !WHITELIST.includes(token1.id)) {
+    return tokenAmount0.times(price0).times(BigDecimal.fromString('2'))
+  }
+
+  // take double value of the whitelisted token amount
+  if (!WHITELIST.includes(token0.id) && WHITELIST.includes(token1.id)) {
+    return tokenAmount1.times(price1).times(BigDecimal.fromString('2'))
+  }
+
+  // neither token is on white list, tracked volume is 0
+  return ZERO_BD
 }

--- a/src/mappings/pricing.ts
+++ b/src/mappings/pricing.ts
@@ -1,6 +1,6 @@
 /* eslint-disable prefer-const */
-import { Pair, Token } from '../types/schema'
-import { BigDecimal, Address, log } from '@graphprotocol/graph-ts/index'
+import { Pair, Token, Bundle } from '../types/schema'
+import { BigDecimal, Address } from '@graphprotocol/graph-ts/index'
 import { ZERO_BD, ONE_BD, factoryContract, ADDRESS_ZERO } from './helpers'
 
 const DAI_WETH_PAIR = '0xa478c2975ab1ea89e8196811f51a7b7ade33eb11'
@@ -15,7 +15,8 @@ const USDT_WETH_PAIR = '0x0d4a11d5eeaac28ec3f61d100daf4d40471f1852'
 const WETH_ADDRESS = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
 
 // only count derived ETH prices in WETH pairs with at least this much WETH reserve
-const ETH_RESERVE_THRESHOLD = BigDecimal.fromString('0.1')
+let ETH_RESERVE_THRESHOLD = BigDecimal.fromString('0.1')
+
 function deriveEthPrice(pairAddress: string, tokenAddress: string): BigDecimal {
   let tokensPerEth = ZERO_BD
   // loop through each stablecoin and find eth price
@@ -156,4 +157,3 @@ export function getTrackedVolumeUSD(
 
   return ZERO_BD // case where neither token is ETH or stablecoin
 }
-

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -48,6 +48,8 @@ templates:
       abis:
         - name: Pair
           file: ./abis/pair.json
+        - name: Factory
+          file: ./abis/factory.json
       eventHandlers:
         - event: Mint(indexed address,uint256,uint256)
           handler: handleMint


### PR DESCRIPTION
- move all liquidity updates into sync handler ( no need to do this in burn, mint, swap handlers)
- move all rate calculations into sync (same as above)
- update with more stablecoins for USD pairs 
- update volume amounts to only track with certain white listed tokens 
- remove wethPair reference in token store 
- USD derivations 
    - use only tracked amoutns for global volume liquidity 
   - use tracked amounts if possible for pairs, derived if no tracked 
   - tokens uses tracked for volume if possible, derived if no tracked - always derived for liquidity

