### PR TITLE
docs: fix graphql query in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This query fetches aggredated data from all uniswap pairs and tokens, to give a 
 
 ```graphql
 {
-  uniswapFactory(id: "1") {
+  uniswapFactories(first: 1) {
     pairCount
     totalVolumeUSD
     totalLiquidityUSD


### PR DESCRIPTION
With the current query, I get this response when I paste it into [graph explorer](https://thegraph.com/explorer/subgraph/uniswap/uniswap-v2):

```json
{
  "data": {
    "uniswapFactory": null
  }
}
```

With my fix, I get this:

```json
{
  "data": {
    "uniswapFactories": [
      {
        "pairCount": 2144,
        "totalLiquidityUSD": "49163319.07526841907329529111859568",
        "totalVolumeUSD": "623554293.8948292752323272523217859"
      }
    ]
  }
}
```