### PR TITLE
Fallback to Token Lists for reverting methods, solves #33

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "python.formatting.provider": "black"
+  "python.formatting.provider": "black",
+  "editor.tabSize": 2,
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,3 @@
 {
-  "python.formatting.provider": "black",
-  "editor.tabSize": 2,
+  "python.formatting.provider": "black"
 }

--- a/src/mappings/helpers.ts
+++ b/src/mappings/helpers.ts
@@ -5,6 +5,11 @@ import { ERC20SymbolBytes } from '../types/Factory/ERC20SymbolBytes'
 import { ERC20NameBytes } from '../types/Factory/ERC20NameBytes'
 import { User, Bundle, Token, LiquidityPosition, LiquidityPositionSnapshot, Pair } from '../types/schema'
 import { Factory as FactoryContract } from '../types/templates/Pair/Factory'
+import { 
+  fetchTokenSymbolFromTokenList,
+  fetchTokenNameFromTokenList,
+  fetchTokenDecimalsFromTokenList,
+} from './tokenList'
 
 export const ADDRESS_ZERO = '0x0000000000000000000000000000000000000000'
 export const FACTORY_ADDRESS = '0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f'
@@ -53,6 +58,8 @@ export function isNullEthValue(value: string): boolean {
   return value == '0x0000000000000000000000000000000000000000000000000000000000000001'
 }
 
+
+
 export function fetchTokenSymbol(tokenAddress: Address): string {
   // hard coded override
   if (tokenAddress.toHexString() == '0xe0b7927c4af23765cb51314a0e0521a9645f0e2a') {
@@ -72,6 +79,9 @@ export function fetchTokenSymbol(tokenAddress: Address): string {
       if (!isNullEthValue(symbolResultBytes.value.toHexString())) {
         symbolValue = symbolResultBytes.value.toString()
       }
+    } else {
+      // Fallback to token list
+      symbolValue = fetchTokenSymbolFromTokenList(tokenAddress)
     }
   } else {
     symbolValue = symbolResult.value
@@ -99,6 +109,9 @@ export function fetchTokenName(tokenAddress: Address): string {
       if (!isNullEthValue(nameResultBytes.value.toHexString())) {
         nameValue = nameResultBytes.value.toString()
       }
+    } else {
+      // Fallback to token list
+      nameValue = fetchTokenNameFromTokenList(tokenAddress)
     }
   } else {
     nameValue = nameResult.value
@@ -124,6 +137,8 @@ export function fetchTokenDecimals(tokenAddress: Address): BigInt {
   let decimalResult = contract.try_decimals()
   if (!decimalResult.reverted) {
     decimalValue = decimalResult.value
+  } else {
+    return fetchTokenDecimalsFromTokenList(tokenAddress)
   }
   return BigInt.fromI32(decimalValue as i32)
 }
@@ -185,3 +200,4 @@ export function createLiquiditySnapshot(position: LiquidityPosition, event: Ethe
   position.historicalSnapshots = snapshots
   position.save()
 }
+

--- a/src/mappings/helpers.ts
+++ b/src/mappings/helpers.ts
@@ -76,7 +76,7 @@ export function fetchTokenSymbol(tokenAddress: Address): string {
       }
     } else {
       // Fallback to token list
-      log.debug('Token symbol not defined in ERC20 Contract', [tokenAddress.toString()])
+      log.debug('Token symbol not defined in ERC20 Contract', [tokenAddress.toHexString()])
       symbolValue = fetchTokenSymbolFromTokenList(tokenAddress)
     }
   } else {
@@ -102,7 +102,7 @@ export function fetchTokenName(tokenAddress: Address): string {
       }
     } else {
       // Fallback to token list
-      log.debug('Token name not defined in ERC20 Contract',  [tokenAddress.toString()])
+      log.debug('Token name not defined in ERC20 Contract',  [tokenAddress.toHexString()])
       nameValue = fetchTokenNameFromTokenList(tokenAddress)
     }
   } else {
@@ -130,7 +130,7 @@ export function fetchTokenDecimals(tokenAddress: Address): BigInt {
   if (!decimalResult.reverted) {
     decimalValue = decimalResult.value
   } else {
-    log.debug('Token decimals not defined in ERC20 Contract', [tokenAddress.toString()])
+    log.debug('Token decimals not defined in ERC20 Contract', [tokenAddress.toHexString()])
     return fetchTokenDecimalsFromTokenList(tokenAddress)
   }
   return BigInt.fromI32(decimalValue as i32)

--- a/src/mappings/helpers.ts
+++ b/src/mappings/helpers.ts
@@ -61,11 +61,6 @@ export function isNullEthValue(value: string): boolean {
 
 
 export function fetchTokenSymbol(tokenAddress: Address): string {
-  // hard coded override
-  if (tokenAddress.toHexString() == '0xe0b7927c4af23765cb51314a0e0521a9645f0e2a') {
-    return 'DGD'
-  }
-
   let contract = ERC20.bind(tokenAddress)
   let contractSymbolBytes = ERC20SymbolBytes.bind(tokenAddress)
 
@@ -81,6 +76,7 @@ export function fetchTokenSymbol(tokenAddress: Address): string {
       }
     } else {
       // Fallback to token list
+      log.debug('Token symbol not defined in ERC20 Contract', [tokenAddress.toString()])
       symbolValue = fetchTokenSymbolFromTokenList(tokenAddress)
     }
   } else {
@@ -91,11 +87,6 @@ export function fetchTokenSymbol(tokenAddress: Address): string {
 }
 
 export function fetchTokenName(tokenAddress: Address): string {
-  // hard coded override
-  if (tokenAddress.toHexString() == '0xe0b7927c4af23765cb51314a0e0521a9645f0e2a') {
-    return 'DGD'
-  }
-
   let contract = ERC20.bind(tokenAddress)
   let contractNameBytes = ERC20NameBytes.bind(tokenAddress)
 
@@ -111,6 +102,7 @@ export function fetchTokenName(tokenAddress: Address): string {
       }
     } else {
       // Fallback to token list
+      log.debug('Token name not defined in ERC20 Contract',  [tokenAddress.toString()])
       nameValue = fetchTokenNameFromTokenList(tokenAddress)
     }
   } else {
@@ -138,6 +130,7 @@ export function fetchTokenDecimals(tokenAddress: Address): BigInt {
   if (!decimalResult.reverted) {
     decimalValue = decimalResult.value
   } else {
+    log.debug('Token decimals not defined in ERC20 Contract', [tokenAddress.toString()])
     return fetchTokenDecimalsFromTokenList(tokenAddress)
   }
   return BigInt.fromI32(decimalValue as i32)

--- a/src/mappings/helpers.ts
+++ b/src/mappings/helpers.ts
@@ -76,7 +76,7 @@ export function fetchTokenSymbol(tokenAddress: Address): string {
       }
     } else {
       // Fallback to token list
-      log.debug('Token symbol not defined in ERC20 Contract', [tokenAddress.toHexString()])
+      log.warning('Token symbol not defined in ERC20 Contract', [tokenAddress.toHexString()])
       symbolValue = fetchTokenSymbolFromTokenList(tokenAddress)
     }
   } else {
@@ -102,7 +102,7 @@ export function fetchTokenName(tokenAddress: Address): string {
       }
     } else {
       // Fallback to token list
-      log.debug('Token name not defined in ERC20 Contract',  [tokenAddress.toHexString()])
+      log.warning('Token name not defined in ERC20 Contract',  [tokenAddress.toHexString()])
       nameValue = fetchTokenNameFromTokenList(tokenAddress)
     }
   } else {
@@ -130,7 +130,7 @@ export function fetchTokenDecimals(tokenAddress: Address): BigInt {
   if (!decimalResult.reverted) {
     decimalValue = decimalResult.value
   } else {
-    log.debug('Token decimals not defined in ERC20 Contract', [tokenAddress.toHexString()])
+    log.warning('Token decimals not defined in ERC20 Contract', [tokenAddress.toHexString()])
     return fetchTokenDecimalsFromTokenList(tokenAddress)
   }
   return BigInt.fromI32(decimalValue as i32)

--- a/src/mappings/helpers.ts
+++ b/src/mappings/helpers.ts
@@ -76,7 +76,7 @@ export function fetchTokenSymbol(tokenAddress: Address): string {
       }
     } else {
       // Fallback to token list
-      log.warning('Token symbol not defined in ERC20 Contract', [tokenAddress.toHexString()])
+      log.warning('Token symbol not defined in ERC20 Contract: {}', [tokenAddress.toHexString()])
       symbolValue = fetchTokenSymbolFromTokenList(tokenAddress)
     }
   } else {
@@ -102,7 +102,7 @@ export function fetchTokenName(tokenAddress: Address): string {
       }
     } else {
       // Fallback to token list
-      log.warning('Token name not defined in ERC20 Contract',  [tokenAddress.toHexString()])
+      log.warning('Token name not defined in ERC20 Contract: {}',  [tokenAddress.toHexString()])
       nameValue = fetchTokenNameFromTokenList(tokenAddress)
     }
   } else {
@@ -130,7 +130,7 @@ export function fetchTokenDecimals(tokenAddress: Address): BigInt {
   if (!decimalResult.reverted) {
     decimalValue = decimalResult.value
   } else {
-    log.warning('Token decimals not defined in ERC20 Contract', [tokenAddress.toHexString()])
+    log.warning('Token decimals not defined in ERC20 Contract: {}', [tokenAddress.toHexString()])
     return fetchTokenDecimalsFromTokenList(tokenAddress)
   }
   return BigInt.fromI32(decimalValue as i32)

--- a/src/mappings/tokenList.ts
+++ b/src/mappings/tokenList.ts
@@ -1,0 +1,114 @@
+import {
+  Address,
+  Bytes,
+  BigInt,
+  ipfs,
+  json,
+  JSONValueKind,
+} from '@graphprotocol/graph-ts'
+import { Token } from '../types/schema'
+
+const TOKEN_LIST_IPFS = 'QmUCbHRcJczJJMxKw4Ma69DtDPz4Dbi16PzTj8arGkTx6w' // Kleros T2CR (t2crtokens.eth)
+
+// Fallback to tokenlist if ERC20 function reverts
+export function fetchTokenFromTokenList(tokenAddress: Address) : Token | null {
+  
+  // Retrieve the Token List
+  let tokenListBytes = ipfs.cat(TOKEN_LIST_IPFS)
+
+  // Stop if no result from IPFS
+  if(tokenListBytes == null) {
+    return null
+  }
+
+  // Extract the token list object
+  let tokenListJson = json.fromBytes(<Bytes>tokenListBytes)
+  if(tokenListJson.kind != JSONValueKind.OBJECT) {
+    return null
+  }
+  let tokenList = tokenListJson.toObject()
+
+  // Extract the tokens from the token list
+  if(!tokenList.isSet('tokens')) {
+    return null
+  }
+  let tokensJson = tokenListJson.toObject().get('tokens')
+  if(tokensJson.kind != JSONValueKind.ARRAY) {
+    return null
+  }
+  let tokens = tokensJson.toArray()
+    
+  for (let i: i32 = 0, len: i32 = tokens.length; i < len; i++) {
+    // Check type
+    if(tokens[i].kind != JSONValueKind.OBJECT) {
+      continue
+    }
+    let tokenData = tokens[i].toObject()
+
+    // Check Chain is mainnet
+    if(
+      !tokenData.isSet('chainId') || 
+      tokenData.get('chainId').kind != JSONValueKind.NUMBER || 
+      tokenData.get('chainId').toI64() != 1
+    ) {
+      continue
+    }
+
+    // Check Token Address
+    if(
+      !tokenData.isSet('address') ||
+      tokenData.get('address').kind != JSONValueKind.STRING ||
+      tokenData.get('address').toString() != tokenAddress.toString()
+    ) {
+      continue
+    }
+
+    // Build Token with best-effort
+    let token = new Token(tokenAddress.toString())
+    if(tokenData.isSet('symbol') && tokenData.get('symbol').kind == JSONValueKind.STRING) {
+      token.symbol = tokenData.get('symbol').toString()
+    }
+    if(tokenData.isSet('name') && tokenData.get('name').kind == JSONValueKind.STRING) {
+      token.name = tokenData.get('name').toString()
+    }
+    if(tokenData.isSet('decimals') && tokenData.get('decimals').kind == JSONValueKind.NUMBER) {
+      token.decimals = tokenData.get('decimals').toBigInt()
+    }
+
+    return token
+    
+  }
+
+  return null
+  
+}
+
+// Helper to get a token symbol from the token list
+export function fetchTokenSymbolFromTokenList(tokenAddress: Address): string {
+  let token = fetchTokenFromTokenList(tokenAddress)
+  if(token) {
+    return token.symbol
+  } else {
+    return 'unknown'
+  }
+}
+
+// Helper to get a token name from the token list
+export function fetchTokenNameFromTokenList(tokenAddress: Address): string {
+  let token = fetchTokenFromTokenList(tokenAddress)
+  if(token) {
+    return token.name
+  } else {
+    return 'unknown'
+  }
+}
+
+// Helper to get a token decimals from the token list
+export function fetchTokenDecimalsFromTokenList(tokenAddress: Address): BigInt {
+  let token = fetchTokenFromTokenList(tokenAddress)
+  if(token) {
+    return token.decimals
+  } else {
+    return null
+  }
+}

--- a/src/mappings/tokenList.ts
+++ b/src/mappings/tokenList.ts
@@ -57,7 +57,7 @@ export function fetchTokenFromTokenList(tokenAddress: Address) : Token | null {
       tokenData.get('chainId').kind != JSONValueKind.NUMBER || 
       tokenData.get('chainId').toI64() != 1
     ) {
-      //log.debug('Skipping token not on mainnet: {}', [tokenData.get('chainId').toString()])
+      log.debug('Skipping token not on mainnet: {}', [tokenData.get('chainId').toString()])
       continue
     }
 
@@ -65,7 +65,7 @@ export function fetchTokenFromTokenList(tokenAddress: Address) : Token | null {
     if(
       !tokenData.isSet('address') ||
       tokenData.get('address').kind != JSONValueKind.STRING ||
-      tokenData.get('address').toString() != tokenAddress.toHexString()
+      Address.fromString(tokenData.get('address').toString()) != tokenAddress
     ) {
       //log.debug('Skipping address: {}', [tokenData.get('address').toString()])
       continue

--- a/src/mappings/tokenList.ts
+++ b/src/mappings/tokenList.ts
@@ -64,24 +64,24 @@ export function fetchTokenFromTokenList(tokenAddress: Address) : Token | null {
     if(
       !tokenData.isSet('address') ||
       tokenData.get('address').kind != JSONValueKind.STRING ||
-      tokenData.get('address').toString() != tokenAddress.toString()
+      tokenData.get('address').toString() != tokenAddress.toHexString()
     ) {
       continue
     }
 
     // Build Token with best-effort
-    let token = new Token(tokenAddress.toString())
+    let token = new Token(tokenAddress.toHexString())
     if(tokenData.isSet('symbol') && tokenData.get('symbol').kind == JSONValueKind.STRING) {
       token.symbol = tokenData.get('symbol').toString()
-      log.info('Token symbol found in Token List', [tokenAddress.toString(), token.symbol])
+      log.info('Token symbol found in Token List', [tokenAddress.toHexString(), token.symbol])
     }
     if(tokenData.isSet('name') && tokenData.get('name').kind == JSONValueKind.STRING) {
       token.name = tokenData.get('name').toString()
-      log.info('Token name found in Token List', [tokenAddress.toString(), token.name])
+      log.info('Token name found in Token List', [tokenAddress.toHexString(), token.name])
     }
     if(tokenData.isSet('decimals') && tokenData.get('decimals').kind == JSONValueKind.NUMBER) {
       token.decimals = tokenData.get('decimals').toBigInt()
-      log.info('Token decimals found in Token List', [tokenAddress.toString(), token.decimals.toString()])
+      log.info('Token decimals found in Token List', [tokenAddress.toHexString(), token.decimals.toString()])
     }
 
     return token


### PR DESCRIPTION
Hello,

This Pull Request proposes to fallback to Token List standard when ERC20 contracts have not implemented some of the optional functions `name()`, `symbol`, `decimals()`, as described in issue #33.

## Token List

The [Token list](https://tokenlists.org) used in the proposed implementation is the [Kleros T2CR](https://tokenlists.org/token-list?url=t2crtokens.eth). It would be trivial to add the support of multiple token lists, but the reasons for implementing only Kleros list for now are the following:
* The Uniswap default token list does not contain any token that reverts on these methods
* Kleros T2CR is one of the pre-loaded list in the Uniswap app
* Kleros Court has a defined community process, which allows proposing in the future more ERC20 tokens there and certifying these three properties (name, symbol, decimals) - See detailed here: https://tokens.kleros.io/

## Implementation

The proposed implementation works as follow:

* It retrieves the Token List from IPFS using the IPFS hash of the Token list. Note that the hash is used instead of the ENS domain due to the limited support in the graph-node `ens` API. If/when a token is added in the IPFS list, it can be used automatically.
* It validates the structure of the JSON file using the graph-node `json` library. No external libraries such as `ajv` have been used as they are not supported yet by AssemblyScript.
* It searches for the token by `address` and `chainId` in the list, and when found retrieves the three properties.
* The hardcoded support of DGD token is also removed, since it is not needed anymore with this implementation and it was incorrect anyway.

## Results

The resulting Graph is available here: https://thegraph.com/explorer/subgraph/mtahon/uniswap-tokenlist
The outcome for the few examples provided in issue #33 and the DGD hardcoded token are the following:

### DGD Token

This token _is_ defined in Kleros token list, and in the Uniswap's subgraph the values  of `name` and `decimals` are currently incorrect.

```graphql
{
  tokens(where: {symbol:"DGD"} ) {
    id
    symbol
    name
    decimals
  }
}
```

__Without Token List__
```graphql
{
  "data": {
    "tokens": [
      {
        "decimals": "0",
        "id": "0xe0b7927c4af23765cb51314a0e0521a9645f0e2a",
        "name": "DGD",
        "symbol": "DGD"
      }
    ]
  }
}
```

__With Token List__
```graphql
{
  "data": {
    "tokens": [
      {
        "decimals": "9",
        "id": "0xe0b7927c4af23765cb51314a0e0521a9645f0e2a",
        "name": "DigixDAO",
        "symbol": "DGD"
      }
    ]
  }
}
```

### Token 0xeb9951021698b42e4399f9cbb6267aa35f82d59d

This token _is_ defined in Kleros list, all values are retrieved properly:


```graphql
{
  tokens(where: {id:"0xeb9951021698b42e4399f9cbb6267aa35f82d59d"} ) {
    id
    symbol
    name
    decimals
  }
}
```

__Without Token List__
```graphql
{
  "data": {
    "tokens": [
      {
        "decimals": "0",
        "id": "0xeb9951021698b42e4399f9cbb6267aa35f82d59d",
        "name": "unknown",
        "symbol": "unknown"
      }
    ]
  }
}
```

__With Token List__
```graphql
{
  "data": {
    "tokens": [
      {
        "decimals": "18",
        "id": "0xeb9951021698b42e4399f9cbb6267aa35f82d59d",
        "name": "Líf",
        "symbol": "LIF"
      }
    ]
  }
}
```

### Token 0x1f0d3048b3d49de0ed6169a443dbb049e6daa6ce

This token _is not_ defined in Kleros list, therefore there is no change

```graphql
{
  tokens(where: {id:"0x1f0d3048b3d49de0ed6169a443dbb049e6daa6ce"} ) {
    id
    symbol
    name
    decimals
  }
}
```
__Without Token List__
```graphql
{
  "data": {
    "tokens": [
      {
        "decimals": "0",
        "id": "0x1f0d3048b3d49de0ed6169a443dbb049e6daa6ce",
        "name": "unknown",
        "symbol": "BET99"
      }
    ]
  }
}
```

__With Token List__

```graphql
{
  "data": {
    "tokens": [
      {
        "decimals": "0",
        "id": "0x1f0d3048b3d49de0ed6169a443dbb049e6daa6ce",
        "name": "unknown",
        "symbol": "BET99"
      }
    ]
  }
}
```

Please let me know any feedback or suggestion to improve.

Best Regards,
Mathieu
