### PR TITLE
gasUsed and gasPrice in a Transaction

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -129,6 +129,8 @@ type Transaction @entity {
   id: ID! # txn hash
   blockNumber: BigInt!
   timestamp: BigInt!
+  gasUsed: BigDecimal!
+  gasPrice: BigDecimal!
   # This is not the reverse of Mint.transaction; it is only used to
   # track incomplete mints (similar for burns and swaps)
   mints: [Mint]!

--- a/src/mappings/core.ts
+++ b/src/mappings/core.ts
@@ -61,6 +61,8 @@ export function handleTransfer(event: Transfer): void {
     transaction = new Transaction(transactionHash)
     transaction.blockNumber = event.block.number
     transaction.timestamp = event.block.timestamp
+    transaction.gasUsed = event.transaction.gasUsed.toBigDecimal()
+    transaction.gasPrice = event.transaction.gasPrice.toBigDecimal()
     transaction.mints = []
     transaction.burns = []
     transaction.swaps = []
@@ -469,6 +471,8 @@ export function handleSwap(event: Swap): void {
     transaction = new Transaction(event.transaction.hash.toHexString())
     transaction.blockNumber = event.block.number
     transaction.timestamp = event.block.timestamp
+    transaction.gasUsed = event.transaction.gasUsed.toBigDecimal()
+    transaction.gasPrice = event.transaction.gasPrice.toBigDecimal()
     transaction.mints = []
     transaction.swaps = []
     transaction.burns = []


### PR DESCRIPTION
Hello, I wanted to account for the transaction costs in trades and liquidity provisioning and I was missing the necessary information for that in the subgraph. I think there is no reason to not include this data as it's made readily available by the graph API.

The deployment of the modified version is accessible [here](https://thegraph.com/explorer/subgraph/benesjan/uniswap-v2).