### PR TITLE
Fixing id collisions in complex txs or in multiple txs in block

### DIFF
--- a/src/mappings/helpers.ts
+++ b/src/mappings/helpers.ts
@@ -169,16 +169,20 @@ export function createUser(address: Address): void {
 }
 
 export function createLiquiditySnapshot(position: LiquidityPosition, event: EthereumEvent): void {
-  let timestamp = event.block.timestamp.toI32()
   let bundle = Bundle.load('1')
   let pair = Pair.load(position.pair)
   let token0 = Token.load(pair.token0)
   let token1 = Token.load(pair.token1)
 
   // create new snapshot
-  let snapshot = new LiquidityPositionSnapshot(position.id.concat(timestamp.toString()))
+  let id = position.id
+    .concat("-")
+    .concat(event.transaction.hash.toHexString())
+    .concat("-")
+    .concat(event.logIndex.toString())
+  let snapshot = new LiquidityPositionSnapshot(id)
   snapshot.liquidityPosition = position.id
-  snapshot.timestamp = timestamp
+  snapshot.timestamp = event.block.timestamp.toI32()
   snapshot.block = event.block.number.toI32()
   snapshot.user = position.user
   snapshot.pair = position.pair


### PR DESCRIPTION
In case of multiple txs from 1 user address interacting with the same pool within 1 block  or in case of multiple deposits and withdrawals to the same pool within 1 tx the ids of snapshots collide. For this reason I added tx hash and logIndex to the id. This is not a serious bug but I think it's good to fix it as it improves data consistency.