### PR TITLE
[Bug Fix] Adding tokens with unknown symbol

### DIFF
--- a/src/mappings/helpers.ts
+++ b/src/mappings/helpers.ts
@@ -67,6 +67,9 @@ export function fetchTokenSymbol(tokenAddress: Address): string {
   if (tokenAddress.toHexString() == '0xbdeb4b83251fb146687fa19d1c660f99411eefe3') {
     return 'SVD'
   }
+  if (tokenAddress.toHexString() == '0xbb9bc244d798123fde783fcc1c72d3bb8c189413') {
+    return 'TheDAO'
+  }
 
   let contract = ERC20.bind(tokenAddress)
   let contractSymbolBytes = ERC20SymbolBytes.bind(tokenAddress)
@@ -102,6 +105,9 @@ export function fetchTokenName(tokenAddress: Address): string {
   }
   if (tokenAddress.toHexString() == '0xbdeb4b83251fb146687fa19d1c660f99411eefe3') {
     return 'savedroid'
+  }
+  if (tokenAddress.toHexString() == '0xbb9bc244d798123fde783fcc1c72d3bb8c189413') {
+    return 'TheDAO'
   }
 
   let contract = ERC20.bind(tokenAddress)
@@ -145,6 +151,9 @@ export function fetchTokenDecimals(tokenAddress: Address): BigInt {
   }
   if (tokenAddress.toHexString() == '0xbdeb4b83251fb146687fa19d1c660f99411eefe3') {
     return BigInt.fromI32(18)
+  }
+  if (tokenAddress.toHexString() == '0xbb9bc244d798123fde783fcc1c72d3bb8c189413') {
+    return BigInt.fromI32(16)
   }
 
   let contract = ERC20.bind(tokenAddress)

--- a/src/mappings/helpers.ts
+++ b/src/mappings/helpers.ts
@@ -61,6 +61,9 @@ export function fetchTokenSymbol(tokenAddress: Address): string {
   if (tokenAddress.toHexString() == '0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9') {
     return 'AAVE'
   }
+  if (tokenAddress.toHexString() == '0xeb9951021698b42e4399f9cbb6267aa35f82d59d') {
+    return 'LIF'
+  }
 
   let contract = ERC20.bind(tokenAddress)
   let contractSymbolBytes = ERC20SymbolBytes.bind(tokenAddress)
@@ -90,6 +93,9 @@ export function fetchTokenName(tokenAddress: Address): string {
   }
   if (tokenAddress.toHexString() == '0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9') {
     return 'Aave Token'
+  }
+  if (tokenAddress.toHexString() == '0xeb9951021698b42e4399f9cbb6267aa35f82d59d') {
+    return 'Lif'
   }
 
   let contract = ERC20.bind(tokenAddress)
@@ -126,6 +132,9 @@ export function fetchTokenTotalSupply(tokenAddress: Address): BigInt {
 export function fetchTokenDecimals(tokenAddress: Address): BigInt {
   // hardcode overrides
   if (tokenAddress.toHexString() == '0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9') {
+    return BigInt.fromI32(18)
+  }
+  if (tokenAddress.toHexString() == '0xeb9951021698b42e4399f9cbb6267aa35f82d59d') {
     return BigInt.fromI32(18)
   }
 

--- a/src/mappings/helpers.ts
+++ b/src/mappings/helpers.ts
@@ -64,6 +64,9 @@ export function fetchTokenSymbol(tokenAddress: Address): string {
   if (tokenAddress.toHexString() == '0xeb9951021698b42e4399f9cbb6267aa35f82d59d') {
     return 'LIF'
   }
+  if (tokenAddress.toHexString() == '0xbdeb4b83251fb146687fa19d1c660f99411eefe3') {
+    return 'SVD'
+  }
 
   let contract = ERC20.bind(tokenAddress)
   let contractSymbolBytes = ERC20SymbolBytes.bind(tokenAddress)
@@ -96,6 +99,9 @@ export function fetchTokenName(tokenAddress: Address): string {
   }
   if (tokenAddress.toHexString() == '0xeb9951021698b42e4399f9cbb6267aa35f82d59d') {
     return 'Lif'
+  }
+  if (tokenAddress.toHexString() == '0xbdeb4b83251fb146687fa19d1c660f99411eefe3') {
+    return 'savedroid'
   }
 
   let contract = ERC20.bind(tokenAddress)
@@ -135,6 +141,9 @@ export function fetchTokenDecimals(tokenAddress: Address): BigInt {
     return BigInt.fromI32(18)
   }
   if (tokenAddress.toHexString() == '0xeb9951021698b42e4399f9cbb6267aa35f82d59d') {
+    return BigInt.fromI32(18)
+  }
+  if (tokenAddress.toHexString() == '0xbdeb4b83251fb146687fa19d1c660f99411eefe3') {
     return BigInt.fromI32(18)
   }
 

--- a/src/mappings/helpers.ts
+++ b/src/mappings/helpers.ts
@@ -70,6 +70,9 @@ export function fetchTokenSymbol(tokenAddress: Address): string {
   if (tokenAddress.toHexString() == '0xbb9bc244d798123fde783fcc1c72d3bb8c189413') {
     return 'TheDAO'
   }
+  if (tokenAddress.toHexString() == '0x38c6a68304cdefb9bec48bbfaaba5c5b47818bb2') {
+    return 'HPB'
+  }
 
   let contract = ERC20.bind(tokenAddress)
   let contractSymbolBytes = ERC20SymbolBytes.bind(tokenAddress)
@@ -108,6 +111,9 @@ export function fetchTokenName(tokenAddress: Address): string {
   }
   if (tokenAddress.toHexString() == '0xbb9bc244d798123fde783fcc1c72d3bb8c189413') {
     return 'TheDAO'
+  }
+  if (tokenAddress.toHexString() == '0x38c6a68304cdefb9bec48bbfaaba5c5b47818bb2') {
+    return 'HPBCoin'
   }
 
   let contract = ERC20.bind(tokenAddress)
@@ -154,6 +160,9 @@ export function fetchTokenDecimals(tokenAddress: Address): BigInt {
   }
   if (tokenAddress.toHexString() == '0xbb9bc244d798123fde783fcc1c72d3bb8c189413') {
     return BigInt.fromI32(16)
+  }
+  if (tokenAddress.toHexString() == '0x38c6a68304cdefb9bec48bbfaaba5c5b47818bb2') {
+    return BigInt.fromI32(18)
   }
 
   let contract = ERC20.bind(tokenAddress)

--- a/src/mappings/helpers.ts
+++ b/src/mappings/helpers.ts
@@ -5,6 +5,7 @@ import { ERC20SymbolBytes } from '../types/Factory/ERC20SymbolBytes'
 import { ERC20NameBytes } from '../types/Factory/ERC20NameBytes'
 import { User, Bundle, Token, LiquidityPosition, LiquidityPositionSnapshot, Pair } from '../types/schema'
 import { Factory as FactoryContract } from '../types/templates/Pair/Factory'
+import { TokenDefinition } from './tokenDefinition'
 
 export const ADDRESS_ZERO = '0x0000000000000000000000000000000000000000'
 export const FACTORY_ADDRESS = '0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f'
@@ -54,24 +55,10 @@ export function isNullEthValue(value: string): boolean {
 }
 
 export function fetchTokenSymbol(tokenAddress: Address): string {
-  // hard coded overrides
-  if (tokenAddress.toHexString() == '0xe0b7927c4af23765cb51314a0e0521a9645f0e2a') {
-    return 'DGD'
-  }
-  if (tokenAddress.toHexString() == '0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9') {
-    return 'AAVE'
-  }
-  if (tokenAddress.toHexString() == '0xeb9951021698b42e4399f9cbb6267aa35f82d59d') {
-    return 'LIF'
-  }
-  if (tokenAddress.toHexString() == '0xbdeb4b83251fb146687fa19d1c660f99411eefe3') {
-    return 'SVD'
-  }
-  if (tokenAddress.toHexString() == '0xbb9bc244d798123fde783fcc1c72d3bb8c189413') {
-    return 'TheDAO'
-  }
-  if (tokenAddress.toHexString() == '0x38c6a68304cdefb9bec48bbfaaba5c5b47818bb2') {
-    return 'HPB'
+  // static definitions overrides
+  let staticDefinition = TokenDefinition.fromAddress(tokenAddress)
+  if(staticDefinition != null) {
+    return (staticDefinition as TokenDefinition).symbol
   }
 
   let contract = ERC20.bind(tokenAddress)
@@ -96,24 +83,10 @@ export function fetchTokenSymbol(tokenAddress: Address): string {
 }
 
 export function fetchTokenName(tokenAddress: Address): string {
-  // hard coded overrides
-  if (tokenAddress.toHexString() == '0xe0b7927c4af23765cb51314a0e0521a9645f0e2a') {
-    return 'DGD'
-  }
-  if (tokenAddress.toHexString() == '0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9') {
-    return 'Aave Token'
-  }
-  if (tokenAddress.toHexString() == '0xeb9951021698b42e4399f9cbb6267aa35f82d59d') {
-    return 'Lif'
-  }
-  if (tokenAddress.toHexString() == '0xbdeb4b83251fb146687fa19d1c660f99411eefe3') {
-    return 'savedroid'
-  }
-  if (tokenAddress.toHexString() == '0xbb9bc244d798123fde783fcc1c72d3bb8c189413') {
-    return 'TheDAO'
-  }
-  if (tokenAddress.toHexString() == '0x38c6a68304cdefb9bec48bbfaaba5c5b47818bb2') {
-    return 'HPBCoin'
+  // static definitions overrides
+  let staticDefinition = TokenDefinition.fromAddress(tokenAddress)
+  if(staticDefinition != null) {
+    return (staticDefinition as TokenDefinition).name
   }
 
   let contract = ERC20.bind(tokenAddress)
@@ -148,21 +121,10 @@ export function fetchTokenTotalSupply(tokenAddress: Address): BigInt {
 }
 
 export function fetchTokenDecimals(tokenAddress: Address): BigInt {
-  // hardcode overrides
-  if (tokenAddress.toHexString() == '0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9') {
-    return BigInt.fromI32(18)
-  }
-  if (tokenAddress.toHexString() == '0xeb9951021698b42e4399f9cbb6267aa35f82d59d') {
-    return BigInt.fromI32(18)
-  }
-  if (tokenAddress.toHexString() == '0xbdeb4b83251fb146687fa19d1c660f99411eefe3') {
-    return BigInt.fromI32(18)
-  }
-  if (tokenAddress.toHexString() == '0xbb9bc244d798123fde783fcc1c72d3bb8c189413') {
-    return BigInt.fromI32(16)
-  }
-  if (tokenAddress.toHexString() == '0x38c6a68304cdefb9bec48bbfaaba5c5b47818bb2') {
-    return BigInt.fromI32(18)
+  // static definitions overrides
+  let staticDefinition = TokenDefinition.fromAddress(tokenAddress)
+  if(staticDefinition != null) {
+    return (staticDefinition as TokenDefinition).decimals
   }
 
   let contract = ERC20.bind(tokenAddress)

--- a/src/mappings/tokenDefinition.ts
+++ b/src/mappings/tokenDefinition.ts
@@ -27,7 +27,7 @@ export class TokenDefinition {
       Address.fromString('0xe0b7927c4af23765cb51314a0e0521a9645f0e2a'),
       'DGD',
       'DGD',
-      BigInt.fromI32(18)
+      BigInt.fromI32(9)
     )
     staticDefinitions.push(tokenDGD)
 

--- a/src/mappings/tokenDefinition.ts
+++ b/src/mappings/tokenDefinition.ts
@@ -1,0 +1,99 @@
+import {
+  Address,
+  BigInt,
+} from "@graphprotocol/graph-ts"
+
+// Initialize a Token Definition with the attributes
+export class TokenDefinition {
+  address : Address
+  symbol: string
+  name: string
+  decimals: BigInt
+
+  // Initialize a Token Definition with its attributes
+  constructor(address: Address, symbol: string, name: string, decimals: BigInt) {
+    this.address = address
+    this.symbol = symbol
+    this.name = name
+    this.decimals = decimals
+  }
+
+  // Get all tokens with a static defintion
+  static getStaticDefinitions(): Array<TokenDefinition> {
+    let staticDefinitions = new Array<TokenDefinition>(6)
+
+    // Add DGD
+    let tokenDGD = new TokenDefinition(
+      Address.fromString('0xe0b7927c4af23765cb51314a0e0521a9645f0e2a'),
+      'DGD',
+      'DGD',
+      BigInt.fromI32(18)
+    )
+    staticDefinitions.push(tokenDGD)
+
+    // Add AAVE
+    let tokenAAVE = new TokenDefinition(
+      Address.fromString('0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9'),
+      'AAVE',
+      'Aave Token',
+      BigInt.fromI32(18)
+    )
+    staticDefinitions.push(tokenAAVE)
+
+    // Add LIF
+    let tokenLIF = new TokenDefinition(
+      Address.fromString('0xeb9951021698b42e4399f9cbb6267aa35f82d59d'),
+      'LIF',
+      'Lif',
+      BigInt.fromI32(18)
+    )
+    staticDefinitions.push(tokenLIF)
+
+    // Add SVD
+    let tokenSVD = new TokenDefinition(
+      Address.fromString('0xbdeb4b83251fb146687fa19d1c660f99411eefe3'),
+      'SVD',
+      'savedroid',
+      BigInt.fromI32(18)
+    )
+    staticDefinitions.push(tokenSVD)
+
+    // Add TheDAO
+    let tokenTheDAO = new TokenDefinition(
+      Address.fromString('0xbb9bc244d798123fde783fcc1c72d3bb8c189413'),
+      'TheDAO',
+      'TheDAO',
+      BigInt.fromI32(16)
+    )
+    staticDefinitions.push(tokenTheDAO)
+
+    // Add HPB
+    let tokenHPB = new TokenDefinition(
+      Address.fromString('0x38c6a68304cdefb9bec48bbfaaba5c5b47818bb2'),
+      'HPB',
+      'HPBCoin',
+      BigInt.fromI32(18)
+    )
+    staticDefinitions.push(tokenHPB)
+
+    return staticDefinitions
+  }
+
+  // Helper for hardcoded tokens
+  static fromAddress(tokenAddress: Address) : TokenDefinition | null {
+    let staticDefinitions = this.getStaticDefinitions()
+    let tokenAddressHex = tokenAddress.toHexString()
+
+    // Search the definition using the address
+    for (let i = 0; i < staticDefinitions.length; i++) {
+      let staticDefinition = staticDefinitions[i]
+      if(staticDefinition.address.toHexString() == tokenAddressHex) {
+        return staticDefinition
+      }
+    }
+
+    // If not found, return null
+    return null
+  }
+
+}


### PR DESCRIPTION
There are some missing token definitions in the Uniswap subgraph due to the associated ERC20 Token reverting on `name()`, `decimals()` or `symbol`.

These token can be retrieved easily from the [subgraph explorer](https://thegraph.com/explorer/subgraph/uniswap/uniswap-v2) with the following query:

**Query:**
```graphql
{
  tokens(
    where:{symbol:"unknown"}
  ) {
    id
    symbol
    name
    decimals
  }
}
```

**Example of Result:**
```graphql
   [...]
      {
        "decimals": "0",
        "id": "0xeb9951021698b42e4399f9cbb6267aa35f82d59d",
        "name": "unknown",
        "symbol": "unknown"
      }
```


As a result of this, the associated `uniswap.info` analytics page is broken (wrong price, missing symbols, ..), and also sometimes even the Coingecko page which relies on the subgraph data.

I submitted previously a more elegant solution (#33) with JSON and IPFS, which was unfortunately reverted (#51) to the IPFS function used being not deterministic. Since there are only a few tokens with the problem, I am proposing this simple PR adding 4 hard-coded tokens with the values taken from the Etherscan page. I only added these 4 since the information was available, the other addresses are either not contract addresses or have no information available at all.

The introduced risk is near zero since this was already in place for two other tokens, and it only affects the tokens with these addresses. Note that the addresses are lower case as per The Graph behavior.

Thanks for considering it.