### PR TITLE
Fix typo Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Every transaction on Uniswap is stored. Each transaction contains an array of mi
 
 #### Mint, Burn, Swap
 
-These contain specifc information about a transaction. Things like which pair triggered the transaction, amounts, sender, recipient, and more. Each is linked to a parent Transaction entity.
+These contain specific information about a transaction. Things like which pair triggered the transaction, amounts, sender, recipient, and more. Each is linked to a parent Transaction entity.
 
 ## Example Queries
 


### PR DESCRIPTION
# Fix Typo in README.md

## Summary of Changes
- Corrected a typo: "specifc" to "specific" in the `README.md` file for improved accuracy.

---

## Additional Notes
This is a minor documentation update and does not affect the functionality of the project.  
Please review and merge at your convenience. Thank you! 😊
