### PR TITLE
fix: pin all GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,14 +17,14 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           ref: ${{ github.event.pull_request.head.ref || '' }}
           token: ${{ secrets.github_token }}
           persist-credentials: false
 
       - name: Set up node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version: "18.x"
           registry-url: https://registry.npmjs.org
@@ -33,7 +33,7 @@ jobs:
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}


### PR DESCRIPTION
## Summary
Pin all GitHub Actions references in workflow files to full-length commit SHAs to mitigate supply chain attacks via tag mutation.

## What changed
- **CI.yml**: Pinned `actions/checkout@v2`, `actions/setup-node@v3`, and `actions/cache@v3` to their resolved commit SHAs with version comments

## Test plan
- [ ] CI passes with the pinned SHAs (checkout, setup-node, cache all resolve correctly)

## Session context
Resolved each tag to its commit SHA via the GitHub API (`git/ref/tags/{tag}`). Each `uses:` line retains a `# vN` comment for human readability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)