### PR TITLE
update megaeth v2 to canonical factory (4326)

### DIFF
--- a/config/megaeth-mainnet/chain.ts
+++ b/config/megaeth-mainnet/chain.ts
@@ -1,12 +1,12 @@
 import { Address, BigDecimal, BigInt } from '@graphprotocol/graph-ts/index'
 
-export const FACTORY_ADDRESS = '0x9b7f6a5c2ea87ed485bc8eb92a21aab84b077453'
+export const FACTORY_ADDRESS = '0xbf56488c857a881ae7e3bed27cf99c10a7ab7e50'
 
 const WETH = '0x4200000000000000000000000000000000000006'.toLowerCase()
 const USDT0 = '0xb8ce59fc3717ada4c02eadf9682a9e934f625ebb'.toLowerCase()
 const USDTm = '0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7'.toLowerCase()
 const MEGA = '0x28B7E77f82B25B95953825F1E3eA0E36c1c29861'.toLowerCase()
-const WETH_USDT0 = '0x3EA468B2F9118413D03fbB85363FbfcCA805B780'.toLowerCase()
+const WETH_USDT0 = '0xa674eb32ac4036fd4b28febcae23d3817a5fd04c'.toLowerCase()
 
 export const REFERENCE_TOKEN = WETH
 export const STABLE_TOKEN_PAIRS = [WETH_USDT0]

--- a/config/megaeth-mainnet/config.json
+++ b/config/megaeth-mainnet/config.json
@@ -1,5 +1,5 @@
 {
   "network": "megaeth-mainnet",
-  "factory": "0x9b7f6a5c2ea87ed485bc8eb92a21aab84b077453",
-  "startblock": "3637431"
+  "factory": "0xbf56488c857a881ae7e3bed27cf99c10a7ab7e50",
+  "startblock": "7009645"
 }


### PR DESCRIPTION
## Problem

The `megaeth-mainnet` v2 config indexes the **stale early factory** `0x9b7f6a5c2ea87ed485bc8eb92a21aab84b077453` (only **1 pair**) instead of the canonical UniswapV2Factory (**7 pairs**). Same class of issue as [v3-subgraph#299](https://github.com/Uniswap/v3-subgraph/pull/299) and the v4 fix.

## Source of truth

`Uniswap/contracts` [`deployments/4326.md`](https://github.com/Uniswap/contracts/blob/main/deployments/4326.md):
- **UniswapV2Factory:** `0xbf56488c857a881ae7e3bed27cf99c10a7ab7e50`

## Changes

| File | Field | Before | After |
|---|---|---|---|
| `config.json` | factory | `0x9b7f6a5c…77453` | `0xbf56488c…7e50` |
| `config.json` | startblock | `3637431` | `7009645` |
| `chain.ts` | `FACTORY_ADDRESS` | `0x9b7f6a5c…77453` | `0xbf56488c…7e50` |
| `chain.ts` | `WETH_USDT0` (STABLE_TOKEN_PAIRS) | `0x3EA468B2…B780` | `0xa674eb32…d04c` |

Token addresses (WETH/USDT0/USDTm/MEGA, whitelist, stablecoins) are factory-independent and unchanged.

## On-chain verification (MegaETH mainnet, 4326)
- `allPairsLength()`: configured factory `0x9b7f6a5c…` = **1**, canonical `0xbf56488c…` = **7**.
- Canonical factory first has bytecode at block **7,009,645** → `startblock` (canonical Jan-30-2026 deployment batch, alongside v3 factory @ 7,009,646 and v4 PoolManager @ 7,009,653).
- New stable pair `0xa674eb32…`: `factory()` = canonical, WETH/USDT0, live reserves. The old `0x3EA468B2…` reports `factory()` = `0x9b7f6a5c…` (deprecated) and would stop being indexed after the switch.

## Follow-up
Redeploy the megaeth v2 subgraph after merge.