### PR TITLE
add arc-mainnet (5042) support

### DIFF
--- a/config/arc-mainnet/.subgraph-env
+++ b/config/arc-mainnet/.subgraph-env
@@ -1,0 +1,2 @@
+V2_TOKEN_SUBGRAPH_NAME="uniswap-v2-tokens-arc-mainnet"
+V2_SUBGRAPH_NAME="uniswap-v2-arc-mainnet"

--- a/config/arc-mainnet/chain.ts
+++ b/config/arc-mainnet/chain.ts
@@ -1,0 +1,38 @@
+import { Address, BigDecimal, BigInt } from '@graphprotocol/graph-ts/index'
+
+export const FACTORY_ADDRESS = '0x89e5db8b5aa49aa85ac63f691524311aeb649eba'
+
+// Arc (chainId 5042) is Circle's USDC-native L1: the native gas token is USDC and there is no
+// wrapped native (the deployment's "WETH9" slot is the UnsupportedProtocol stub), so pairs pair
+// against native USDC and USDC is the reference token. Because the reference token IS the dollar,
+// getEthPriceInUSD() returns 1 — opted in by including REFERENCE_TOKEN in STABLE_TOKEN_PAIRS.
+const USDC = '0x3600000000000000000000000000000000000000'.toLowerCase()
+const EURC = '0x89B50855Aa3bE2F677cD6303Cec089B5F319D72a'.toLowerCase()
+const USYC = '0xe9185F0c5F296Ed1797AaE4238D26CCaBEadb86C'.toLowerCase()
+const CIRBTC = '0x171A4217b86A807A64eB94757Db6849fb4bDbAA0'.toLowerCase() // cirBTC (BTC-pegged) — whitelist only, not a USD stable
+
+export const REFERENCE_TOKEN = USDC
+export const STABLE_TOKEN_PAIRS = [REFERENCE_TOKEN]
+
+// token where amounts should contribute to tracked volume and liquidity
+export const WHITELIST: string[] = [USDC, EURC, USYC, CIRBTC]
+
+// USD-pegged stablecoins only (EURC is EUR-pegged, USYC is yield-bearing → excluded)
+export const STABLECOINS = [USDC]
+
+// minimum liquidity required to count towards tracked volume for pairs with small # of Lps
+export const MINIMUM_USD_THRESHOLD_NEW_PAIRS = BigDecimal.fromString('40000')
+
+// minimum liquidity for price to get tracked
+export const MINIMUM_LIQUIDITY_THRESHOLD_ETH = BigDecimal.fromString('2000')
+
+export class TokenDefinition {
+  address: Address
+  symbol: string
+  name: string
+  decimals: BigInt
+}
+
+export const STATIC_TOKEN_DEFINITIONS: TokenDefinition[] = []
+
+export const SKIP_TOTAL_SUPPLY: string[] = []

--- a/config/arc-mainnet/chain.ts
+++ b/config/arc-mainnet/chain.ts
@@ -10,12 +10,13 @@ const USDC = '0x3600000000000000000000000000000000000000'.toLowerCase()
 const EURC = '0x89B50855Aa3bE2F677cD6303Cec089B5F319D72a'.toLowerCase()
 const USYC = '0xe9185F0c5F296Ed1797AaE4238D26CCaBEadb86C'.toLowerCase()
 const CIRBTC = '0x171A4217b86A807A64eB94757Db6849fb4bDbAA0'.toLowerCase() // cirBTC (BTC-pegged) — whitelist only, not a USD stable
+const WETH = '0x128cC466B61f542da60c70e3aA11c10e19B84EDB'.toLowerCase() // bridged ETH — whitelist only (not the native/reference; Arc's native is USDC)
 
 export const REFERENCE_TOKEN = USDC
 export const STABLE_TOKEN_PAIRS = [REFERENCE_TOKEN]
 
 // token where amounts should contribute to tracked volume and liquidity
-export const WHITELIST: string[] = [USDC, EURC, USYC, CIRBTC]
+export const WHITELIST: string[] = [USDC, EURC, USYC, CIRBTC, WETH]
 
 // USD-pegged stablecoins only (EURC is EUR-pegged, USYC is yield-bearing → excluded)
 export const STABLECOINS = [USDC]

--- a/config/arc-mainnet/config.json
+++ b/config/arc-mainnet/config.json
@@ -1,0 +1,5 @@
+{
+  "network": "arc-mainnet",
+  "factory": "0x89e5db8b5aa49aa85ac63f691524311aeb649eba",
+  "startblock": "1948011"
+}

--- a/script/utils/prepareNetwork.ts
+++ b/script/utils/prepareNetwork.ts
@@ -5,6 +5,7 @@ import * as process from 'process'
 
 export enum NETWORK {
   ARBITRUM = 'arbitrum-one',
+  ARC = 'arc-mainnet',
   AVALANCHE = 'avalanche',
   BASE = 'base',
   BLAST = 'blast-mainnet',

--- a/src/common/pricing.ts
+++ b/src/common/pricing.ts
@@ -13,6 +13,12 @@ import {
 import { ADDRESS_ZERO, ONE_BD, ZERO_BD } from './constants'
 
 export function getEthPriceInUSD(): BigDecimal {
+  // On chains where the reference token is itself a USD stablecoin (e.g. Arc, whose native gas
+  // token is USDC and which has no wrapped-native / reference-stable pair), the reference token's
+  // USD price is 1 by definition. Such chains opt in by including REFERENCE_TOKEN in STABLE_TOKEN_PAIRS.
+  if (STABLE_TOKEN_PAIRS.includes(REFERENCE_TOKEN)) {
+    return ONE_BD
+  }
   // create an array with same length as STABLE_TOKEN_PAIRS
   let stableTokenPairs = new Array<Pair | null>(STABLE_TOKEN_PAIRS.length)
   let stableTokenReserves = new Array<BigDecimal>(STABLE_TOKEN_PAIRS.length)


### PR DESCRIPTION
Adds **Arc mainnet** (chainId 5042, Circle's USDC-native L1) to the v2 + v2-tokens subgraphs.

Arc's native gas token is USDC and there's no wrapped native, so pairs pair against native USDC (`0x3600…0000`, 6 dec) and **USDC is the reference token**. Because the reference token *is* the dollar, `getEthPriceInUSD()` returns **1** — opted in via `STABLE_TOKEN_PAIRS = [REFERENCE_TOKEN]`; the guard only fires on `STABLE_TOKEN_PAIRS.includes(REFERENCE_TOKEN)`, so every other chain is unaffected. (Mirrors v3-subgraph#300.)

**Changes**
- `src/common/pricing.ts` — `return ONE_BD` when the reference token is in `STABLE_TOKEN_PAIRS`.
- `config/arc-mainnet/` — V2 factory `0x89e5db8b…` @ startBlock **1948011**; `REFERENCE_TOKEN = USDC`, `STABLECOINS = [USDC]`, `WHITELIST = [USDC, EURC, USYC, cirBTC]`, thresholds mirror `tempo`.
- `prepareNetwork.ts` — register `arc-mainnet`.

`EURC` (EUR-pegged), `USYC` (yield-bearing) and `cirBTC` (`0x171A4217…`, BTC-pegged) are whitelisted but kept out of `STABLECOINS`. Builds verified for v2 + v2-tokens.

Addresses per [5042.md](https://github.com/Uniswap/contracts/blob/main/deployments/5042.md); startBlock from explorer.arc.io.