### PR TITLE
add ink (57073) support

### DIFF
--- a/config/ink/.subgraph-env
+++ b/config/ink/.subgraph-env
@@ -1,0 +1,2 @@
+V2_TOKEN_SUBGRAPH_NAME="uniswap-v2-tokens-ink"
+V2_SUBGRAPH_NAME="uniswap-v2-ink"

--- a/config/ink/chain.ts
+++ b/config/ink/chain.ts
@@ -1,0 +1,33 @@
+import { Address, BigDecimal, BigInt } from '@graphprotocol/graph-ts/index'
+
+export const FACTORY_ADDRESS = '0xfe57a6ba1951f69ae2ed4abe23e0f095df500c04'
+
+const WETH = '0x4200000000000000000000000000000000000006'.toLowerCase()
+const USDCE = '0xF1815bd50389c46847f0Bda824eC8da914045D14'.toLowerCase()
+const USDT0 = '0x0200C29006150606B650577BBE7B6248F58470c1'.toLowerCase()
+const WETH_USDCE = '0xfa3a9015e5fd82485835e23260bc98adadca8a01'.toLowerCase()
+
+export const REFERENCE_TOKEN = WETH
+export const STABLE_TOKEN_PAIRS = [WETH_USDCE]
+
+// token where amounts should contribute to tracked volume and liquidity
+export const WHITELIST: string[] = [WETH, USDCE, USDT0]
+
+export const STABLECOINS = [USDCE, USDT0]
+
+// minimum liquidity required to count towards tracked volume for pairs with small # of Lps
+export const MINIMUM_USD_THRESHOLD_NEW_PAIRS = BigDecimal.fromString('40000')
+
+// minimum liquidity for price to get tracked
+export const MINIMUM_LIQUIDITY_THRESHOLD_ETH = BigDecimal.fromString('1')
+
+export class TokenDefinition {
+  address: Address
+  symbol: string
+  name: string
+  decimals: BigInt
+}
+
+export const STATIC_TOKEN_DEFINITIONS: TokenDefinition[] = []
+
+export const SKIP_TOTAL_SUPPLY: string[] = []

--- a/config/ink/config.json
+++ b/config/ink/config.json
@@ -1,0 +1,5 @@
+{
+  "network": "ink",
+  "factory": "0xfe57a6ba1951f69ae2ed4abe23e0f095df500c04",
+  "startblock": "524511"
+}

--- a/script/utils/prepareNetwork.ts
+++ b/script/utils/prepareNetwork.ts
@@ -10,6 +10,7 @@ export enum NETWORK {
   BLAST = 'blast-mainnet',
   BSC = 'bsc',
   CELO = 'celo',
+  INK = 'ink',
   LINEA = 'linea',
   ETHEREUM = 'ethereum',
   TEMPO = 'tempo',


### PR DESCRIPTION
## Summary
- Adds Ink (chain 57073 / network `ink`) as a supported network for the V2 subgraph (both `v2` and `v2-tokens` types).
- **Factory** `0xfe57a6ba1951f69ae2ed4abe23e0f095df500c04`, deployed at block **524511**.
- USD pricing anchored on the **WETH/USDC.e** pair `0xfa3a9015e5fd82485835e23260bc98adadca8a01` (`STABLE_TOKEN_PAIRS`); `REFERENCE_TOKEN = WETH` (`0x4200…0006`).
- Whitelist: WETH, USDC.e (`0xF1815b…45D14`), USDT0 (`0x0200C29…0c1`).
- Stablecoins: USDC.e, USDT0.

Mirrors the megaeth-mainnet config pattern (L2, WETH at `0x4200…0006`). Companion to the Ink work in [v4-subgraph #83](https://github.com/Uniswap/v4-subgraph/pull/83).

Also registers `INK` in the `NETWORK` enum in `script/utils/prepareNetwork.ts` so the build/deploy scripts accept `--network ink`.

## Test plan
- [x] Deployed (per author)
- [x] `STABLE_TOKEN_PAIRS` source pool confirmed on-chain as WETH/USDC.e (token0 `0x4200…0006`, token1 `0xf181…5d14`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)