### PR TITLE
fix(robinhood): set WETH/USDG reference pool for USD pricing

### DIFF
--- a/config/robinhood-mainnet/chain.ts
+++ b/config/robinhood-mainnet/chain.ts
@@ -4,14 +4,14 @@ export const FACTORY_ADDRESS = '0x8bceaa40b9acdfaedf85adf4ff01f5ad6517937f'
 
 // Robinhood chain (chainId 4663). Standard ETH-native config: the reference token is WETH, priced
 // via the WETH/USDG pair. USDG ("Global Dollar", 6 dec) is the USD stablecoin.
-// STABLE_TOKEN_PAIRS is empty until the WETH/USDG v2 pair is created + seeded; until then
-// getEthPriceInUSD() returns 0 (USD metrics read 0; indexing still works). This is NOT the Arc
-// sentinel (which puts REFERENCE_TOKEN in STABLE_TOKEN_PAIRS to force a price of 1) — WETH is volatile.
+// STABLE_TOKEN_PAIRS holds the WETH/USDG pair, used to derive the ETH price in USD. This is NOT the
+// Arc sentinel (which puts REFERENCE_TOKEN in STABLE_TOKEN_PAIRS to force a price of 1) — WETH is volatile.
 const WETH = '0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73'.toLowerCase()
 const USDG = '0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168'.toLowerCase()
+const WETH_USDG_PAIR = '0x8803c117ccae7b5146297876c2a25df135141c4d'
 
 export const REFERENCE_TOKEN = WETH
-export const STABLE_TOKEN_PAIRS: string[] = [] // TODO: [WETH_USDG_PAIR] once the v2 pair is seeded
+export const STABLE_TOKEN_PAIRS: string[] = [WETH_USDG_PAIR]
 
 // token where amounts should contribute to tracked volume and liquidity
 export const WHITELIST: string[] = [WETH, USDG]


### PR DESCRIPTION
Sets the WETH/USDG reference pool for Robinhood so the subgraph can derive ETH→USD pricing (was a zero/empty placeholder → ethPriceUSD=0 → all pools reported $0 TVL/volume).

Reference pools (verified live, ~2 ETH liquidity each):
- v2 pair: 0x8803c117ccae7b5146297876c2a25df135141c4d
- v3 pool: 0x69bfaf19c9f377bb306a89aed9f6b07e2c1a8d9a
- v4 pool: 0x387bf619da4d3fb62bb276482693dba1b9b3520f573cabdfe033384a24125982

2.0.0 versions already deployed to Goldsky and verified (ethPriceUSD ~$1340, USD TVL/volume populating); this PR lands the config so future redeploys don't regress to the placeholder.